### PR TITLE
Add prefix to tag to avoid error due to invalid CSS class names

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@
         var template = document.querySelector(".check-template");
         function updatePanel(node) {
             fetch(node.dataset.readonlyKey, function(doc) {
-                var tag = node.dataset.readonlyKey.substr(0, 6);
+                var tag = "TAG_" + node.dataset.readonlyKey.substr(0, 6);
 
                 // Sort returned checks by name:
                 var sorted = doc.checks.sort(function(a, b) {


### PR DESCRIPTION
I have noticed that if my read-only API key starts with digits or - or _, the class name is not valid and it breaks the rendering/removal of elements. See https://stackoverflow.com/questions/448981/which-characters-are-valid-in-css-class-names-selectors
This is just a simple fix to make sure we always get valid css class names in the tag variable