### PR TITLE
Add Dockerfile and Docker Compose testing manifest.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM abiosoft/caddy
+
+COPY index.html /srv/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,4 @@
+dashboard:
+  build: .
+  ports:
+    - "80:2015"


### PR DESCRIPTION
Add Dockerfile to enable image building. Mainly useful for quickly deploying.
Using the official [Caddy webserver](https://caddyserver.com/) image, latest tag. More info at https://hub.docker.com/r/abiosoft/caddy/

Just adding `index.html` to Caddy's default webroot dir, setting working dir and using default entrypoint.

Build:

```
$ docker build -t dashboard .
```

Run:

```
$ docker run --rm -it -p 80:2015 dashboard
```

FYI, there's a still quicker to test, already built image on my Docker Hub. Test it by running:

```
$ docker run --rm -it -p 80:2015 pataquets/healthchecks-dashboard
```

Using `--rm` instead of `-d` makes the container not go background and it to be deleted after stop. Should stop by `CTRL+C`'ing it.

Also, there is an example Docker Compose file I'm using to build/run/test it, which reproduces the above steps.

Optional improvement to come (maybe in another issue):
- Create an 'official', based on your repo, automated build at Docker Hub for the image: https://docs.docker.com/docker-hub/builds/ . Just requires a free Docker Hub account and a following a quick 'Create automated build' process. I'll be happy to help on it, if needed.