### PR TITLE
Allow specifying API key and title via URL anchor.

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,10 @@
 <body class="theme-light">
     <div id="panel">
         <h1 data-readonly-key="uKatH7z6dSuN2Zyf1luRCmPDkw3fw2U0">Demo Project</h1>
+<!--
         <h1 data-readonly-key="UKsc30GIblRMKKN4BEPXcBNLa8bx4grU">Uptime Checkers</h1>
+        <h1 data-readonly-key="some_other_api_key">Panel name</h1>
+-->
     </div>
 
     <div class="check-template">
@@ -235,7 +238,16 @@
             });
         }
 
-
+        var url = window.location.hash;
+        if (url) {
+            url = url.substr(1);
+            var urlPart = url.split(":");
+            document.querySelectorAll("h1")[0].dataset.readonlyKey = urlPart[0];
+            var title = urlPart[1];
+            if (title) {
+              document.querySelectorAll("h1")[0].innerHTML = title;
+            }
+        }
         document.querySelectorAll("h1").forEach(updatePanel);
         setInterval(function() {
             document.querySelectorAll("h1").forEach(updatePanel);


### PR DESCRIPTION
First attempt at solving my own issue (#3).
Disclaimer: By no means I'm a JS expert, not even too familiar. Thanks to dfabian for helping me with this.
Implementation:
* Read the URL, get the custom API key from the anchor (`#`) onwards.
* If none found, stop and exit. Default source, customized or demo HTML will be shown.
* Otherwise, split the custom API key string into `APIKEY:TITLE` parts, by using colon as separator (`:`).
* Set the API key to the first `<h1>` data element. If a title part is found, set it also as the `<h1>` inner HTML.

This is my first attempt, it can be extended to accept several `APIKEY:TITLE` parts, comma separated, for instance. Feedback welcome.
To make the sample file usable right away without demo clutter, I've commented out the second demo section, leaving it as example.
Coupled with a Docker packaging from #4, you can quickly deploy your own Dashboard in several ways: private with customized HTML, private with default HTML overrided via URL, etc. Even a public instance which can be also used via URL API keys.