### PR TITLE
Stop lying and crashing: Robustness and honesty patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,16 @@ Here are the things that the read-only API keys *cannot* do:
 in your project
 
 
+## Recent Improvements (Honesty & Robustness)
+
+The dashboard has been patched to stop lying and crashing:
+
+*   **API Honesty**: If the API fails (401, 429, 500), the dashboard now actually tells you instead of staying silent and stale.
+*   **Crash Prevention**: Fixed a critical bug where an unnamed check would crash the entire update loop.
+*   **Data Integrity**: Zero-second durations now actually display correctly instead of being hidden by sloppy falsy checks.
+*   **Time Physics**: Clamped "time ago" to 0 so the dashboard stops claiming events happened in the future.
+
+
 ## Docker image
 
 There is an official [Healthchecks.io Status Dashboard Docker image](https://hub.docker.com/r/healthchecks/dashboard)

--- a/index.html
+++ b/index.html
@@ -233,6 +233,11 @@
         }
 
         function duration(v) {
+            v = parseInt(v);
+            if (isNaN(v) || v < 0) {
+                return "??";
+            }
+
             if (v < 60) { // v is seconds
                 return v + " sec";
             }
@@ -275,11 +280,14 @@
                     return;
                 }
 
+                // Filter out null/undefined items just in case the API is having a bad day.
+                var checks = doc.checks.filter(function(item) { return !!item; });
+
                 var tag = "TAG_" + node.dataset.readonlyKey.substr(0, 6);
 
                 // ORIGINAL: Crashed sorting if a check had no name.
                 // FIX: Handle null names gracefully.
-                var sorted = doc.checks.sort(function(a, b) {
+                var sorted = checks.sort(function(a, b) {
                     return (a.name || "").localeCompare(b.name || "")
                 });
 

--- a/index.html
+++ b/index.html
@@ -126,6 +126,17 @@
             font-size: 20px;
         }
 
+        #panel > h1.error {
+            color: #ff3929;
+        }
+
+        #panel > h1.error::after {
+            content: " (Update Failed)";
+            font-size: 14px;
+            font-weight: normal;
+            margin-left: 10px;
+        }
+
         #panel > div {
             padding: 8px 8px 32px 8px;
             font-size: 18px;
@@ -197,12 +208,22 @@
     </svg>
 
     <script>
+        // ORIGINAL: Silent failure on API errors. 
+        // FIX: Actually handle status codes and report failures to the UI.
         function fetch(key, callback) {
             var httpRequest = new XMLHttpRequest();
             httpRequest.onreadystatechange = function() {
                 if (httpRequest.readyState === 4) {
                     if (httpRequest.status === 200) {
-                        callback(JSON.parse(httpRequest.responseText));
+                        try {
+                            callback(JSON.parse(httpRequest.responseText), 200);
+                        } catch (e) {
+                            // Catching malformed JSON because we can't trust the wire.
+                            callback(null, "parse-error");
+                        }
+                    } else {
+                        // Notify that the API is failing instead of staying silent.
+                        callback(null, httpRequest.status);
                     }
                 }
             };
@@ -230,19 +251,36 @@
             return v + " day" + (v == 1 ? "" : "s");
          };
 
+        // ORIGINAL: Reported "negative" time if client clock was behind.
+        // FIX: Time only moves forward. Clamp to 0.
         function timeSince(date) {
             var v = Math.floor((new Date() - date) / 1000);
-            return duration(v);
+            return duration(Math.max(0, v));
          };
 
         var template = document.querySelector(".check-template");
         function updatePanel(node) {
-            fetch(node.dataset.readonlyKey, function(doc) {
+            fetch(node.dataset.readonlyKey, function(doc, status) {
+                if (status !== 200) {
+                    node.classList.add("error");
+                    node.title = "Update failed (status " + status + ")";
+                    return;
+                }
+                node.classList.remove("error");
+                node.title = "";
+
+                // ORIGINAL: Crashed if 'checks' was missing or null.
+                // FIX: Basic validation because objects shouldn't just vanish.
+                if (!doc || !Array.isArray(doc.checks)) {
+                    return;
+                }
+
                 var tag = "TAG_" + node.dataset.readonlyKey.substr(0, 6);
 
-                // Sort returned checks by name:
+                // ORIGINAL: Crashed sorting if a check had no name.
+                // FIX: Handle null names gracefully.
                 var sorted = doc.checks.sort(function(a, b) {
-                    return a.name.localeCompare(b.name)
+                    return (a.name || "").localeCompare(b.name || "")
                 });
 
                 var fragment = document.createDocumentFragment();
@@ -254,11 +292,14 @@
                         var s = timeSince(Date.parse(item.last_ping)) + " ago";
                         div.querySelector(".lp").textContent = s;
                     }
-                    if (item.last_duration) {
-                        var svg = '<svg width="13" height="13" viewBox="0 0 768 768"><use href="#timer" /></svg> ';
-                        div.querySelector(".ld span").textContent = duration(item.last_duration);
+
+                    // ORIGINAL: Sloppy falsy check 'if (item.last_duration)' hid durations of 0.
+                    // FIX: Explicitly check for existence so 0sec actually shows up.
+                    var ld = div.querySelector(".ld");
+                    if (item.last_duration !== undefined && item.last_duration !== null) {
+                        ld.querySelector("span").textContent = duration(item.last_duration);
                     } else {
-                        div.querySelector(".ld").textContent = "";
+                        ld.textContent = "";
                     }
                     fragment.appendChild(div);
                 });


### PR DESCRIPTION
The current dashboard is a fragile house of cards that lies to users when the API fails and crashes if a check is unnamed. This PR adds basic adulthood to the codebase:

1. API Honesty: Stop staying silent when the API fails. The UI now actually tells you if it's stale.
2. Crash Prevention: Fixed a critical bug where null.localeCompare would kill the update loop because somebody forgot to name a check.
3. Data Integrity: Zero-second durations are data, not 'false'. They now show up correctly.
4. Sanity: Events can't happen in the future. Clamped 'time since' to 0.

Stop the silent failures. Adopt this patch.